### PR TITLE
Fix: CursorPaging

### DIFF
--- a/paginator.go
+++ b/paginator.go
@@ -66,7 +66,7 @@ func NewCursorPaginator(store Store, request *http.Request, options *Options) (*
 
 	if options.CursorOptions.Mode == DateModeCursor {
 		// time in cursor is standard timestamp (second)
-		paginator.Cursor = time.Unix(0, GetCursorFromRequest(request, options)*1000000000)
+		paginator.Cursor = time.Unix(0, GetCursorFromRequest(request, options))
 	}
 
 	return paginator, nil
@@ -145,7 +145,7 @@ func (p *CursorPaginator) MakeNextURI() null.String {
 
 	// convert to timestamp if cusror mode is Date
 	if p.Options.CursorOptions.Mode == DateModeCursor {
-		nextCursor = nextCursor.(time.Time).Unix()
+		nextCursor = nextCursor.(time.Time).UnixNano()
 	}
 
 	return null.StringFrom(GenerateCursorURI(p.Limit, nextCursor, p.Options))

--- a/stores.go
+++ b/stores.go
@@ -2,6 +2,7 @@ package paging
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jinzhu/gorm"
 )
@@ -63,10 +64,20 @@ func (s *GORMStore) PaginateCursor(limit int64, cursor interface{}, fieldName st
 
 	q = q.Limit(int(limit))
 
-	if reverse {
-		q = q.Where(fmt.Sprintf("%s < ?", fieldName), cursor)
-	} else {
-		q = q.Where(fmt.Sprintf("%s > ?", fieldName), cursor)
+	zero := true
+	if i, ok := cursor.(int64); ok && i != 0 {
+		zero = false
+	}
+	if v, ok := cursor.(time.Time); ok && v != time.Unix(0, 0) {
+		zero = false
+	}
+
+	if !zero {
+		if reverse {
+			q = q.Where(fmt.Sprintf("%s < ?", fieldName), cursor)
+		} else {
+			q = q.Where(fmt.Sprintf("%s > ?", fieldName), cursor)
+		}
 	}
 
 	q = q.Find(s.items)


### PR DESCRIPTION
When I use Cursor paging, there are some bugs.

- wrong WHERE clause (WHERE id < 0) if cursor is not set
- (timeBase) not correct paging if there are records which datetime is same in seconds. 