### PR TITLE
fix cursor based pagination next URI

### DIFF
--- a/paginator_test.go
+++ b/paginator_test.go
@@ -1,0 +1,15 @@
+package paging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCursorPaginator_Next(t *testing.T) {
+	is := assert.New(t)
+	p := CursorPaginator{count: 10, paginator: &paginator{Limit: 10}}
+	is.False(p.HasNext())
+	p.count = 11
+	is.True(p.HasNext())
+}

--- a/stores.go
+++ b/stores.go
@@ -13,7 +13,7 @@ import (
 // Store is a store.
 type Store interface {
 	PaginateOffset(limit, offset int64, count *int64) error
-	PaginateCursor(limit int64, cursor interface{}, fieldName string, reverse bool) error
+	PaginateCursor(limit int64, cursor interface{}, fieldName string, reverse bool, count *int64) error
 	GetItems() interface{}
 }
 
@@ -58,7 +58,7 @@ func (s *GORMStore) PaginateOffset(limit, offset int64, count *int64) error {
 
 // PaginateCursor paginates items from the store and update page instance for cursor pagination system.
 // cursor can be an ID or a date (time.Time)
-func (s *GORMStore) PaginateCursor(limit int64, cursor interface{}, fieldName string, reverse bool) error {
+func (s *GORMStore) PaginateCursor(limit int64, cursor interface{}, fieldName string, reverse bool, count *int64) error {
 	q := s.db
 
 	q = q.Limit(int(limit))
@@ -70,5 +70,6 @@ func (s *GORMStore) PaginateCursor(limit int64, cursor interface{}, fieldName st
 	}
 
 	q = q.Find(s.items)
+	q.Limit(-1).Count(count)
 	return q.Error
 }

--- a/stores_test.go
+++ b/stores_test.go
@@ -310,3 +310,18 @@ func TestGORMStore_CursorPaginator_Date(t *testing.T) {
 	is.NotNil(err)
 
 }
+
+func TestGORMStore_PaginateCursor_Count(t *testing.T) {
+	is := assert.New(t)
+	rebuildDB()
+
+	var items []User
+	s := GORMStore{db: db.Model(&User{}), items: &items}
+
+	var count int64
+	is.NoError(s.PaginateCursor(DefaultLimit, 0, DefaultCursorDBName, false, &count))
+	is.Equal(int64(100), count)
+
+	is.NoError(s.PaginateCursor(DefaultLimit, 1, DefaultCursorDBName, false, &count))
+	is.Equal(int64(99), count)
+}


### PR DESCRIPTION
We don't want cursor based pagination to return a next URI if there
isn't any item left to be shown.

The offset based pagination already does this by running two SQL
queries: one for retrieving the actual items and the other to count the
total number of items.

This commit adds a SQL query to the cursor based pagination to count the
number of items after the cursor. If the count is lower or equal to the
page size, there isn't any item left and the next URI is null.