### PR TITLE
fix overflow in cursor paginator

### DIFF
--- a/paginator.go
+++ b/paginator.go
@@ -66,7 +66,7 @@ func NewCursorPaginator(store Store, request *http.Request, options *Options) (*
 
 	if options.CursorOptions.Mode == DateModeCursor {
 		// time in cursor is standard timestamp (second)
-		paginator.Cursor = time.Unix(0, GetCursorFromRequest(request, options)*1000000000)
+		paginator.Cursor = time.Unix(GetCursorFromRequest(request, options), 0)
 	}
 
 	return paginator, nil

--- a/paginator_test.go
+++ b/paginator_test.go
@@ -1,0 +1,27 @@
+package paging
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCursorPaginator(t *testing.T) {
+	is := assert.New(t)
+
+	now := time.Unix(1548002340, 0)
+	since := now.UnixNano() / 1e6 // Date.now() in javascript returns a timestamp in milliseconds
+	v := url.Values{"since": []string{strconv.FormatInt(since, 10)}}
+	opts := NewOptions()
+	opts.CursorOptions.Mode = DateModeCursor
+	p, err := NewCursorPaginator(nil, &http.Request{URL: &url.URL{RawQuery: v.Encode()}}, opts)
+	is.NoError(err)
+
+	got, ok := p.Cursor.(time.Time)
+	is.True(ok)
+	is.True(got.After(now), "%v should be after %v", got, now)
+}


### PR DESCRIPTION
We multiply the cursor paginator timestamp by 1e9 for no reason and this
can create an overflow if the timestamp is very large. For example,
we have an overflow with JavaScript's Date.now() which returns a
timestamp in milliseconds.