### PR TITLE
fix cursor base pagination next URI

### DIFF
--- a/stores.go
+++ b/stores.go
@@ -13,7 +13,7 @@ import (
 // Store is a store.
 type Store interface {
 	PaginateOffset(limit, offset int64, count *int64) error
-	PaginateCursor(limit int64, cursor interface{}, fieldName string, reverse bool) error
+	PaginateCursor(limit int64, cursor interface{}, fieldName string, reverse bool, hasnext *bool) error
 	GetItems() interface{}
 }
 
@@ -58,10 +58,10 @@ func (s *GORMStore) PaginateOffset(limit, offset int64, count *int64) error {
 
 // PaginateCursor paginates items from the store and update page instance for cursor pagination system.
 // cursor can be an ID or a date (time.Time)
-func (s *GORMStore) PaginateCursor(limit int64, cursor interface{}, fieldName string, reverse bool) error {
+func (s *GORMStore) PaginateCursor(limit int64, cursor interface{}, fieldName string, reverse bool, hasnext *bool) error {
 	q := s.db
 
-	q = q.Limit(int(limit))
+	q = q.Limit(limit + 1)
 
 	if reverse {
 		q = q.Where(fmt.Sprintf("%s < ?", fieldName), cursor)
@@ -69,6 +69,18 @@ func (s *GORMStore) PaginateCursor(limit int64, cursor interface{}, fieldName st
 		q = q.Where(fmt.Sprintf("%s > ?", fieldName), cursor)
 	}
 
-	q = q.Find(s.items)
-	return q.Error
+	err := q.Find(s.items).Error
+	if err != nil {
+		return err
+	}
+
+	len := getLen(s.items)
+	if int64(len) <= limit {
+		*hasnext = false
+		return nil
+	}
+
+	*hasnext = true
+	_, s.items = popLastElement(s.items)
+	return nil
 }

--- a/stores_test.go
+++ b/stores_test.go
@@ -287,8 +287,7 @@ func TestGORMStore_CursorPaginator_Date(t *testing.T) {
 	is.Equal(20, users[0].Number)
 
 	np, err = np.Next()
-	is.Nil(err)
-	is.Empty(users)
+	is.Error(err)
 
 	// end with request
 	request, _ = http.NewRequest("GET", "http://example.com?limit=20&since-date=1484646856", nil)
@@ -309,4 +308,21 @@ func TestGORMStore_CursorPaginator_Date(t *testing.T) {
 	is.Nil(pp)
 	is.NotNil(err)
 
+}
+
+func TestGORMStore_PaginateCursor_HasNext(t *testing.T) {
+	is := assert.New(t)
+	rebuildDB()
+
+	var items []User
+	s := GORMStore{db: db.Model(&User{}), items: &items}
+
+	var hasnext bool
+	is.NoError(s.PaginateCursor(99, 0, DefaultCursorDBName, false, &hasnext))
+	is.Equal(99, len(items))
+	is.True(hasnext)
+
+	is.NoError(s.PaginateCursor(100, 0, DefaultCursorDBName, false, &hasnext))
+	is.Equal(100, len(items))
+	is.False(hasnext)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -121,3 +121,54 @@ func TestGenerateCursorURI(t *testing.T) {
 	options.CursorOptions.KeyName = "o"
 	is.Equal("?l=14&o=60", GenerateCursorURI(int64(14), int64(60), options))
 }
+
+func Test_GetLastElementField(t *testing.T) {
+	last := getLastElementField(
+		[]struct{ Fieldname int }{
+			{Fieldname: 1},
+			{Fieldname: 2},
+			{Fieldname: 3}},
+		"Fieldname")
+	assert.New(t).Equal(3, last)
+}
+
+func Test_GetLastElementField_Int(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic")
+		}
+		expected := "can't get last element of a value of type int"
+		if r.(string) != expected {
+			t.Fatalf("expected %q, got %q", expected, r)
+		}
+	}()
+	getLastElementField(1, "fieldname")
+}
+
+func Test_GetLastElementField_IntSlice(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic")
+		}
+		expected := "can't get fieldname \"fieldname\" of an element of type int"
+		if r.(string) != expected {
+			t.Fatalf("expected %q, got %q", expected, r)
+		}
+	}()
+	getLastElementField([]int{1}, "fieldname")
+}
+
+func Test_GetLen(t *testing.T) {
+	assert.New(t).Equal(3, getLen([]int{1, 2, 3}))
+}
+
+func Test_PopLastElement(t *testing.T) {
+	array := &[]int{1, 2, 3}
+	last, remaining := popLastElement(array)
+
+	is := assert.New(t)
+	is.Equal(3, last)
+	is.Equal(&[]int{1, 2}, remaining)
+}


### PR DESCRIPTION
We don't want cursor based pagination to return a next URI if there
isn't any item left to be shown.

The offset based pagination already does this by running two SQL
queries: one for retrieving the actual items and the other to count the
total number of items.

This commit increases the limit of the cursor based pagination by one.
If the number of items is lower than or equal to the request limit,
there isn't any item left and the next URI is null.